### PR TITLE
Create missing symlink bin/cc -> bin/gcc

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -49,4 +49,11 @@ install()
 	( cd build && make install; )
 	
 	install_ups
+
+	# if bin/cc is missing (as it is for gcc 4.8.5) create it, because LSST uses cc to build C files
+	if [ ! -e "$PREFIX/bin/cc" ]
+	then
+		echo "\"$PREFIX/bin/cc\" missing; create it as a link to \"$PREFIX/bin/gcc\""
+		ln "$PREFIX/bin/gcc" "$PREFIX/bin/cc"
+	fi
 }


### PR DESCRIPTION
Modified ups/eupspkg.cfg.sh so that after installing gcc it manually adds
a symlink bin/cc -> bin/gcc, because the normal installer omits bin/cc
for unknown reasons and cc is used to build C code
